### PR TITLE
Allow pwsh and work crossplat

### DIFF
--- a/install.cmd
+++ b/install.cmd
@@ -19,7 +19,7 @@ Write-Host Dowloading $tag
 Invoke-WebRequest $download -Out $zip
 
 Write-Host Extracting release files...
-Expand-Archive $zip -Force
+Expand-Archive $zip -Force $pwd
 
 Remove-Item $zip -Force
 Write-Host install completed.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,28 @@
+#!/usr/bin/env pwsh
+
+if (!$IsCoreCLR) {
+    # We only need to do this in Windows PowerShell.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+}
+
+$ErrorActionPreference = "Stop"
+$repo = "PowerShell/PowerShellEditorServices"
+$file = "PowerShellEditorServices.zip"
+
+$releases = "https://api.github.com/repos/$repo/releases"
+
+Write-Host Determining latest release...
+$tag = (Invoke-RestMethod $releases)[0].tag_name
+
+$download = "https://github.com/$repo/releases/download/$tag/$file"
+$zip = "pses.zip"
+
+New-Item -Name $dir -ItemType Directory -Force
+Write-Host Downloading $tag
+Invoke-WebRequest $download -OutFile $zip
+
+Write-Host Extracting release files...
+Expand-Archive $zip $pwd -Force
+
+Remove-Item $zip -Force
+Write-Host install completed.

--- a/plugin/coc-pses.vim
+++ b/plugin/coc-pses.vim
@@ -2,10 +2,17 @@ let s:vimscript_dir = expand('<sfile>:p:h')
 let g:pses_dir      = resolve(expand(s:vimscript_dir . '/../PowerShellEditorServices/PowerShellEditorServices'))
 let g:pses_script   = g:pses_dir . "/Start-EditorServices.ps1"
 
+if(!exists("g:pses_powershell_executable"))
+    let g:pses_powershell_executable = "powershell"
+    if(executable("pwsh"))
+        let g:pses_powershell_executable = "pwsh"
+    endif
+endif
+
 function! s:PSESSetup ()
     call coc#config("languageserver", {
             \   "pses": {
-            \     "command": "powershell",
+            \     "command": g:pses_powershell_executable,
             \     "filetypes": ["ps1", "psm1", "psd1"],
             \     "rootPatterns": [".pses/", ".vim/", ".git/", ".hg/"],
             \     "trace.server": "verbose",
@@ -27,5 +34,11 @@ function! s:PSESSetup ()
             \  }
             \)
 endfunction
+
+" Set the file type to ps1 for ps1, psm1, and psd1
+" 'ps1' is what vim-polyglot uses for styling
+if(&filetype == "")
+    autocmd BufNewFile,BufRead *.ps*1 set filetype=ps1
+endif
 
 autocmd FileType ps1,psd1,psm1 call s:PSESSetup()


### PR DESCRIPTION
The user has the ability to set `g:pses_powershell_executable` in their `Init.vim`. They could set it to: `pwsh`, `powershell`, `pwsh-preview`. If `pwsh` is on the path, we use that - otherwise use `powershell`.

Also, `Expand-Archive` changed behavior apparently between 5.1 and 6... Without pwd, it extracts to a `pses` folder that contains a `PowerShellEditorServices` folder which contains `PowerShellEditorServices`, `Plaster`, etc.

Also, if the filetype isn't set, but it's a powershell file, I set the filetype so coc-pses gets triggered.

I was afraid to touch the first line of the cmd file (I wanted it to just `Get-Content install.ps1` but I wasn't sure if that would break something. 