### PR TITLE
Add mac support back

### DIFF
--- a/autoload/coc/pses.vim
+++ b/autoload/coc/pses.vim
@@ -1,7 +1,14 @@
 let s:root           = expand('<sfile>:h:h:h')
 let s:is_win         = has('win32') || has('win64')
+let s:is_mac = !s:is_windows && !s:is_cygwin
+      \ && (has('mac') || has('macunix') || has('gui_macvim') ||
+      \   (!isdirectory('/proc') && executable('sw_vers')))
 let s:is_vim         = !has('nvim')
 let s:install_script = s:root.'/'.(s:is_win ? 'install.cmd' : 'install.ps1')
+
+if(s:is_mac)
+    let s:install_script = 'pwsh '.s:install_script
+endif
 
 function! coc#pses#install()
     let cwd = getcwd()
@@ -9,4 +16,3 @@ function! coc#pses#install()
     exe '!'.s:install_script
     exe 'lcd '.cwd
 endfunction
-

--- a/autoload/coc/pses.vim
+++ b/autoload/coc/pses.vim
@@ -1,6 +1,6 @@
 let s:root           = expand('<sfile>:h:h:h')
 let s:is_win         = has('win32') || has('win64')
-let s:is_mac = !s:is_windows && !s:is_cygwin
+let s:is_mac = !s:is_win && !has('win32unix')
       \ && (has('mac') || has('macunix') || has('gui_macvim') ||
       \   (!isdirectory('/proc') && executable('sw_vers')))
 let s:is_vim         = !has('nvim')

--- a/install.ps1
+++ b/install.ps1
@@ -5,7 +5,11 @@ if (!$IsCoreCLR) {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 }
 
+# Fail on anything
 $ErrorActionPreference = "Stop"
+# Progress doesn't display properly in vim
+$ProgressPreference = "SilentlyContinue"
+
 $repo = "PowerShell/PowerShellEditorServices"
 $file = "PowerShellEditorServices.zip"
 
@@ -17,7 +21,7 @@ $tag = (Invoke-RestMethod $releases)[0].tag_name
 $download = "https://github.com/$repo/releases/download/$tag/$file"
 $zip = "pses.zip"
 
-New-Item -Name $dir -ItemType Directory -Force
+$null = New-Item -Name $dir -ItemType Directory -Force
 Write-Host Downloading $tag
 Invoke-WebRequest $download -OutFile $zip
 


### PR DESCRIPTION
macOS doesn't support the shebang:

```
#!/usr/bin/env pwsh
```

so we explicitly say `pwsh path/to/install.ps1`

We assume they have `pwsh` on their path since that will be required anyway.

Also this makes the install  script a tad less loud - Progress is not rendered well in vim.