### PR TITLE
Move PSES log to PSES folder

### DIFF
--- a/plugin/coc-pses.vim
+++ b/plugin/coc-pses.vim
@@ -2,6 +2,13 @@ let s:vimscript_dir = expand('<sfile>:p:h')
 let g:pses_dir      = resolve(expand(s:vimscript_dir . '/../PowerShellEditorServices/PowerShellEditorServices'))
 let g:pses_script   = g:pses_dir . "/Start-EditorServices.ps1"
 
+" Let the user specify the log directory for PSES.
+" If the user doesn't specify a location, use the root of vov-pses in a .pses
+" directory.
+if(!exists("g:pses_logs_dir"))
+    let g:pses_logs_dir      = resolve(expand(s:vimscript_dir . '/../.pses/logs/' . strftime('%Y%m%d') . '-' . getpid()))
+endif
+
 if(!exists("g:pses_powershell_executable"))
     let g:pses_powershell_executable = "powershell"
     if(executable("pwsh"))
@@ -23,12 +30,12 @@ function! s:PSESSetup ()
             \       "-HostName", "coc.vim",
             \       "-HostProfileId", "0",
             \       "-HostVersion", "2.0.0",
-            \       "-LogPath", g:pses_dir . "/log.txt",
+            \       "-LogPath", g:pses_logs_dir . "/log.txt",
             \       "-LogLevel", "Diagnostic",
             \       "-FeatureFlags", "[]",
             \       "-BundledModulesPath", g:pses_dir . "/../",
             \       "-Stdio",
-            \       "-SessionDetailsPath", g:pses_dir . "/session"
+            \       "-SessionDetailsPath", g:pses_logs_dir . "/session"
             \     ]
             \    }
             \  }

--- a/plugin/coc-pses.vim
+++ b/plugin/coc-pses.vim
@@ -23,12 +23,12 @@ function! s:PSESSetup ()
             \       "-HostName", "coc.vim",
             \       "-HostProfileId", "0",
             \       "-HostVersion", "2.0.0",
-            \       "-LogPath", ".pses/log.txt",
+            \       "-LogPath", g:pses_dir . "/log.txt",
             \       "-LogLevel", "Diagnostic",
             \       "-FeatureFlags", "[]",
             \       "-BundledModulesPath", g:pses_dir . "/../",
             \       "-Stdio",
-            \       "-SessionDetailsPath", ".pses/session"
+            \       "-SessionDetailsPath", g:pses_dir . "/session"
             \     ]
             \    }
             \  }


### PR DESCRIPTION
This moves the PSES log and session file to the PSES folder within the Plugin as opposed to containing it within the working directory that vim was launched from.

It might be worth adding the PID and/or date to the path like we do with [vscode-powershell](https://github.com/powershell/vscode-powershell) to keep the logs separate between editing sessions.